### PR TITLE
Fix LICENSE file.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,23 +1,21 @@
 BSD 3-Clause License
 
-Copyright (c) 2019 Regents of the University of California and The Board
-of Regents for the Oklahoma Agricultural and Mechanical College
-(acting for and on behalf of Oklahoma State University)
+Copyright (c) 2019, Regents of the University of California and The Board of Regents for the Oklahoma Agricultural and Mechanical College (acting for and on behalf of Oklahoma State University)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-* Neither the name of the copyright holder nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE


### PR DESCRIPTION
Match the `BSD 3-Clause "New" or "Revised" License` template that GitHub provides so that license detection actually works correctly.

#### Before;
```
License:        NOASSERTION
Matched files:  LICENSE
LICENSE:
  Content hash:  49d7d639c8d78568b17a301b31162afec7162483
  License:       NOASSERTION
  Closest non-matching licenses:
    BSD-3-Clause-Clear similarity:  92.49%
    BSD-4-Clause similarity:        92.43%
```
#### After;
```
License:        BSD-3-Clause
Matched files:  LICENSE
LICENSE:
  Content hash:  fa22c672927af9c7334874561198799cbf4bdf31
  Attribution:   Copyright (c) 2019, Regents of the University of California and The Board of Regents for the Oklahoma Agricultural and Mechanical College (acting for and on behalf of Oklahoma State University)
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       BSD-3-Clause
```

Fixes #55.