### PR TITLE
gdsMill: Fix reader/writer ignoring the 'DATATYPE' of 'PATH' records

### DIFF
--- a/compiler/gdsMill/gdsMill/gds2reader.py
+++ b/compiler/gdsMill/gdsMill/gds2reader.py
@@ -251,6 +251,11 @@ class Gds2reader:
                 thisPath.pathType=pathType
                 if(self.debugToTerminal==1):
                     print("\t\t\tPath Type: "+str(pathType))
+            elif(idBits==b'\x0E\x02'):  #Data type
+                dataType = struct.unpack(">h",record[2:4])[0]
+                thisPath.dataType=dataType
+                if(self.debugToTerminal==1):
+                    print("\t\t\tData Type: "+str(dataType))
             elif(idBits==b'\x0F\x03'):  #Path width
                 pathWidth = struct.unpack(">i",record[2:6])[0]
                 thisPath.pathWidth=pathWidth

--- a/compiler/gdsMill/gdsMill/gds2writer.py
+++ b/compiler/gdsMill/gdsMill/gds2writer.py
@@ -238,6 +238,10 @@ class Gds2writer:
             idBits=b'\x16\x02' #purpose layer
             purposeLayer = struct.pack(">h",thisPath.purposeLayer)
             self.writeRecord(idBits+purposeLayer)
+        if(thisPath.dataType is not None):
+            idBits=b'\x0E\x02'  #Data type
+            dataType = struct.pack(">h",thisPath.dataType)
+            self.writeRecord(idBits+dataType)
         if(thisPath.pathType):
             idBits=b'\x21\x02'  #Path type
             pathType = struct.pack(">h",thisPath.pathType)

--- a/compiler/gdsMill/gdsMill/gdsPrimitives.py
+++ b/compiler/gdsMill/gdsMill/gdsPrimitives.py
@@ -33,6 +33,7 @@ class GdsPath:
         self.drawingLayer=""
         self.purposeLayer = None
         self.pathType=""
+        self.dataType=None
         self.pathWidth=""
         self.coordinates=""
         


### PR DESCRIPTION
most readers (like KLayout/Calibre) will not open gds files omitting the
DATATYPE.

Cheers,
Bastian