### PR TITLE
add warning about config file naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We have included the most recent SCN4M_SUBM design rules from [Qflow].
 
 ## Docker Image
 
-**WARNING! Some OpenRAM dependency tools installed in the Docker image are out-of-date.**
+> :warning: **WARNING!** Some OpenRAM dependency tools installed in the Docker image are out-of-date.
 
 We have a pre-configured Ubuntu [Docker](https://www.docker.com/) image
 available that has all tools installed for the [SCMOS] process. It is
@@ -142,6 +142,11 @@ python3 $OPENRAM_HOME/openram.py myconfig
 You can see all of the options for the configuration file in
 $OPENRAM\_HOME/options.py
 
+> :warning: **WARNING!** Config files are imported as Python modules, which
+must adhere to the [requirements for naming Python
+modules](https://docs.python.org/3/reference/simple_stmts.html#the-import-statement).
+In particular, you cannot use a period or any special characters other than an
+underscore. Try using 'p' instead of a period. 
 
 # Unit Tests
 

--- a/compiler/globals.py
+++ b/compiler/globals.py
@@ -295,6 +295,14 @@ def read_config(config_file, is_unit_test=True):
     dir_name = os.path.dirname(config_file)
     module_name = os.path.basename(config_file)
 
+    # Check that the module name adheres to Python's module naming conventions.
+    # This will assist the user in interpreting subsequent errors in loading
+    # the module. Valid Python module naming is described here:
+    #   https://docs.python.org/3/reference/simple_stmts.html#the-import-statement
+    if not module_name.isidentifier():
+        debug.error("Configuration file name is not a valid Python module name: "
+                    "{0}. It should be a valid identifier.".format(module_name))
+
     # Prepend the path to avoid if we are using the example config
     sys.path.insert(0, dir_name)
     # Import the configuration file of which modules to use


### PR DESCRIPTION
Create a warning about naming the configuration files (they should be named as python modules). Add formatting to highlight this gotcha. Format the other warning in the file consistently.