### PR TITLE
Fixes to support TSMC18 technology port

### DIFF
--- a/compiler/base/hierarchy_layout.py
+++ b/compiler/base/hierarchy_layout.py
@@ -1240,6 +1240,16 @@ class layout():
             min_area = drc["minarea_{}".format(self.pwr_grid_layer)]
             width = round_to_grid(sqrt(min_area))
             height = round_to_grid(min_area / width)
+        elif OPTS.tech_name == "tsmc18":
+            min_area = drc["minarea_{}".format(self.pwr_grid_layer)]
+            min_width = drc["minwidth_{}".format(self.pwr_grid_layer)]
+            dir = preferred_directions[self.pwr_grid_layer]
+            if dir == "V":
+                width = round_to_grid(min_width)
+                height = round_to_grid(min_area / width)
+            else:
+                height = round_to_grid(min_width)
+                width = round_to_grid(min_area / height)
         else:
             width = None
             height = None
@@ -1281,6 +1291,16 @@ class layout():
             min_area = drc["minarea_{}".format(self.pwr_grid_layer)]
             width = round_to_grid(sqrt(min_area))
             height = round_to_grid(min_area / width)
+        elif OPTS.tech_name == "tsmc18":
+            min_area = drc["minarea_{}".format(self.pwr_grid_layer)]
+            min_width = drc["minwidth_{}".format(self.pwr_grid_layer)]
+            dir = preferred_directions[self.pwr_grid_layer]
+            if dir == "V":
+                width = round_to_grid(min_width)
+                height = round_to_grid(min_area / width)
+            else:
+                height = round_to_grid(min_width)
+                width = round_to_grid(min_area / height)
         else:
             width = None
             height = None

--- a/compiler/base/pin_layout.py
+++ b/compiler/base/pin_layout.py
@@ -8,7 +8,7 @@
 import debug
 from tech import GDS, drc
 from vector import vector
-from tech import layer, layer_indices, pin_layer
+from tech import layer, layer_indices
 import math
 
 
@@ -47,6 +47,10 @@ class pin_layout:
                     break
             else:
                 # Iterate also the pin_layer
+                try:
+                    from tech import pin_layer
+                except:
+                    pin_layer = {}
                 for (layer_name, lpp) in pin_layer.items():
                     if not lpp:
                         continue

--- a/compiler/base/utils.py
+++ b/compiler/base/utils.py
@@ -148,12 +148,13 @@ def get_gds_pins(pin_names, name, gds_filename, units):
             cell[str(pin_name)] = []
             pin_list = cell_vlsi.getPinShape(str(pin_name))
             for pin_shape in pin_list:
-                (lpp, boundary) = pin_shape
-                rect = [vector(boundary[0], boundary[1]),
-                        vector(boundary[2], boundary[3])]
-                # this is a list because other cells/designs
-                # may have must-connect pins
-                cell[str(pin_name)].append(pin_layout(pin_name, rect, lpp))
+                if pin_shape is not None:
+                    (lpp, boundary) = pin_shape
+                    rect = [vector(boundary[0], boundary[1]),
+                            vector(boundary[2], boundary[3])]
+                    # this is a list because other cells/designs
+                    # may have must-connect pins
+                    cell[str(pin_name)].append(pin_layout(pin_name, rect, lpp))
 
         _GDS_PINS_CACHE[k] = cell
         return dict(cell)

--- a/compiler/modules/bank.py
+++ b/compiler/modules/bank.py
@@ -235,10 +235,14 @@ class bank(design.design):
         # control logic to allow control signals to easily pass over in M3
         # by placing 1 1/4 a cell pitch down because both power connections and inputs/outputs
         # may be routed in M3 or M4
+        # TODO: In tsmc180, is not 1.25 (dff is 6.72. crosses with the first gnd)
+        mult = 1.25
+        if OPTS.tech_name == "tsmc18":
+            mult = 1.5
         x_offset = self.central_bus_width[port] + self.port_address[port].wordline_driver_array.width
         if self.col_addr_size > 0:
             x_offset += self.column_decoder.width + self.col_addr_bus_width
-            y_offset = 1.25 * self.dff.height + self.column_decoder.height
+            y_offset = mult * self.dff.height + self.column_decoder.height
         else:
             y_offset = 0
         self.column_decoder_offsets[port] = vector(-x_offset, -y_offset)
@@ -279,10 +283,14 @@ class bank(design.design):
         # control logic to allow control signals to easily pass over in M3
         # by placing 1 1/4 a cell pitch down because both power connections and inputs/outputs
         # may be routed in M3 or M4
+        # TODO: In tsmc180, is not 1.25 (dff is 6.72. crosses with the first gnd)
+        mult = 1.25
+        if OPTS.tech_name == "tsmc18":
+            mult = 1.5
         x_offset = self.bitcell_array_right  + self.central_bus_width[port] + self.port_address[port].wordline_driver_array.width
         if self.col_addr_size > 0:
             x_offset += self.column_decoder.width + self.col_addr_bus_width
-            y_offset = self.bitcell_array_top + 1.25 * self.dff.height + self.column_decoder.height
+            y_offset = self.bitcell_array_top + mult * self.dff.height + self.column_decoder.height
         else:
             y_offset = self.bitcell_array_top
         self.column_decoder_offsets[port] = vector(x_offset, y_offset)

--- a/compiler/pgates/pand2.py
+++ b/compiler/pgates/pand2.py
@@ -9,6 +9,8 @@ import debug
 from vector import vector
 import pgate
 from sram_factory import factory
+from globals import OPTS
+from tech import drc
 
 
 class pand2(pgate.pgate):
@@ -84,6 +86,31 @@ class pand2(pgate.pgate):
         else:
             # Add INV to the right
             self.inv_inst.place(offset=vector(self.nand_inst.rx(), 0))
+
+            # Extension of the imp in both n and p for tsmc18
+            if OPTS.tech_name == "tsmc18":
+                pmos_rightmost_nand = self.nand_inst.mod.pmos2_pos
+                pmos_leftmost_inv = self.inv_inst.mod.inv_inst_list[0].mod.pmos_pos + vector(self.nand_inst.rx(), 0)
+                nmos_rightmost_nand = self.nand_inst.mod.nmos2_pos
+                nmos_leftmost_inv = self.inv_inst.mod.inv_inst_list[0].mod.nmos_pos + vector(self.nand_inst.rx(), 0)
+                pleft = pmos_rightmost_nand.x + self.nand_inst.mod.pmos_right.active_width + drc("implant_enclose_active")
+                pright = pmos_leftmost_inv.x - drc("implant_enclose_active")
+                ptop = pmos_rightmost_nand.y + self.nand_inst.mod.pmos_right.active_height + \
+                       max(drc("implant_enclose_active"), drc("implant_to_channel"))
+                pbottom = pmos_rightmost_nand.y - max(drc("implant_enclose_active"), drc("implant_to_channel"))
+                self.add_rect(layer="pimplant",
+                              offset=vector(pleft, pbottom),
+                              width=pright - pleft,
+                              height=ptop - pbottom)
+                nleft = nmos_rightmost_nand.x + self.nand_inst.mod.nmos_right.active_width + drc("implant_enclose_active")
+                nright = nmos_leftmost_inv.x - drc("implant_enclose_active")
+                ntop = nmos_rightmost_nand.y + self.nand_inst.mod.nmos_right.active_height + \
+                       max(drc("implant_enclose_active"), drc("implant_to_channel"))
+                nbottom = nmos_rightmost_nand.y - max(drc("implant_enclose_active"), drc("implant_to_channel"))
+                self.add_rect(layer="nimplant",
+                              offset=vector(nleft, nbottom),
+                              width=nright - nleft,
+                              height=ntop - nbottom)
 
     def route_supply_rails(self):
         """ Add vdd/gnd rails to the top, (middle), and bottom. """

--- a/compiler/pgates/pand3.py
+++ b/compiler/pgates/pand3.py
@@ -9,6 +9,8 @@ import debug
 from vector import vector
 import pgate
 from sram_factory import factory
+from globals import OPTS
+from tech import drc
 
 
 class pand3(pgate.pgate):
@@ -89,6 +91,31 @@ class pand3(pgate.pgate):
         else:
             # Add INV to the right
             self.inv_inst.place(offset=vector(self.nand_inst.rx(), 0))
+
+            # Extension of the imp in both n and p for tsmc18
+            if OPTS.tech_name == "tsmc18":
+                pmos_rightmost_nand = self.nand_inst.mod.pmos3_pos
+                pmos_leftmost_inv = self.inv_inst.mod.inv_inst_list[0].mod.pmos_pos + vector(self.nand_inst.rx(), 0)
+                nmos_rightmost_nand = self.nand_inst.mod.nmos3_pos
+                nmos_leftmost_inv = self.inv_inst.mod.inv_inst_list[0].mod.nmos_pos + vector(self.nand_inst.rx(), 0)
+                pleft = pmos_rightmost_nand.x + self.nand_inst.mod.pmos_right.active_width + drc("implant_enclose_active")
+                pright = pmos_leftmost_inv.x - drc("implant_enclose_active")
+                ptop = pmos_rightmost_nand.y + self.nand_inst.mod.pmos_right.active_height + \
+                       max(drc("implant_enclose_active"), drc("implant_to_channel"))
+                pbottom = pmos_rightmost_nand.y - max(drc("implant_enclose_active"), drc("implant_to_channel"))
+                self.add_rect(layer="pimplant",
+                              offset=vector(pleft, pbottom),
+                              width=pright - pleft,
+                              height=ptop - pbottom)
+                nleft = nmos_rightmost_nand.x + self.nand_inst.mod.nmos_right.active_width + drc("implant_enclose_active")
+                nright = nmos_leftmost_inv.x - drc("implant_enclose_active")
+                ntop = nmos_rightmost_nand.y + self.nand_inst.mod.nmos_right.active_height + \
+                       max(drc("implant_enclose_active"), drc("implant_to_channel"))
+                nbottom = nmos_rightmost_nand.y - max(drc("implant_enclose_active"), drc("implant_to_channel"))
+                self.add_rect(layer="nimplant",
+                              offset=vector(nleft, nbottom),
+                              width=nright - nleft,
+                              height=ntop - nbottom)
 
     def route_supply_rails(self):
         """ Add vdd/gnd rails to the top, (middle), and bottom. """

--- a/compiler/pgates/pand4.py
+++ b/compiler/pgates/pand4.py
@@ -9,6 +9,8 @@ import debug
 from vector import vector
 import pgate
 from sram_factory import factory
+from globals import OPTS
+from tech import drc
 
 
 class pand4(pgate.pgate):
@@ -90,6 +92,31 @@ class pand4(pgate.pgate):
         else:
             # Add INV to the right
             self.inv_inst.place(offset=vector(self.nand_inst.rx(), 0))
+
+            # Extension of the imp in both n and p for tsmc18
+            if OPTS.tech_name == "tsmc18":
+                pmos_rightmost_nand = self.nand_inst.mod.pmos4_pos
+                pmos_leftmost_inv = self.inv_inst.mod.inv_inst_list[0].mod.pmos_pos + vector(self.nand_inst.rx(), 0)
+                nmos_rightmost_nand = self.nand_inst.mod.nmos4_pos
+                nmos_leftmost_inv = self.inv_inst.mod.inv_inst_list[0].mod.nmos_pos + vector(self.nand_inst.rx(), 0)
+                pleft = pmos_rightmost_nand.x + self.nand_inst.mod.pmos_right.active_width + drc("implant_enclose_active")
+                pright = pmos_leftmost_inv.x - drc("implant_enclose_active")
+                ptop = pmos_rightmost_nand.y + self.nand_inst.mod.pmos_right.active_height + \
+                       max(drc("implant_enclose_active"), drc("implant_to_channel"))
+                pbottom = pmos_rightmost_nand.y - max(drc("implant_enclose_active"), drc("implant_to_channel"))
+                self.add_rect(layer="pimplant",
+                              offset=vector(pleft, pbottom),
+                              width=pright - pleft,
+                              height=ptop - pbottom)
+                nleft = nmos_rightmost_nand.x + self.nand_inst.mod.nmos_right.active_width + drc("implant_enclose_active")
+                nright = nmos_leftmost_inv.x - drc("implant_enclose_active")
+                ntop = nmos_rightmost_nand.y + self.nand_inst.mod.nmos_right.active_height + \
+                       max(drc("implant_enclose_active"), drc("implant_to_channel"))
+                nbottom = nmos_rightmost_nand.y - max(drc("implant_enclose_active"), drc("implant_to_channel"))
+                self.add_rect(layer="nimplant",
+                              offset=vector(nleft, nbottom),
+                              width=nright - nleft,
+                              height=ntop - nbottom)
 
     def route_supply_rails(self):
         """ Add vdd/gnd rails to the top, (middle), and bottom. """

--- a/compiler/pgates/pgate.py
+++ b/compiler/pgates/pgate.py
@@ -242,10 +242,17 @@ class pgate(design.design):
 
         # To the right a spacing away from the pmos right active edge
         # Also, avoid to do intersection of nimp and pimp
-        # TODO: The pimplant_to_nimplant is new
+        # The pimplant_to_nimplant is new
+        pimp_to_nimp = 0
+        imp_to_active = 0
+        try:
+            pimp_to_nimp = drc("pimplant_to_nimplant")
+            imp_to_active = drc("implant_to_active")
+        except:
+            pass
         contact_xoffset = pmos_pos.x + pmos.active_width \
-                          + max(self.active_space, 2*drc("implant_enclose_active") + drc("pimplant_to_nimplant"),
-                                drc("implant_to_active") + drc("implant_enclose_active"))
+                          + max(self.active_space, 2*drc("implant_enclose_active") + pimp_to_nimp,
+                                imp_to_active + drc("implant_enclose_active"))
 
         # Must be at least an well enclosure of active down
         # from the top of the well
@@ -368,11 +375,18 @@ class pgate(design.design):
         # To the right a spacing away from the nmos right active edge
         # Also, avoid to do intersection of nimp and pimp
         # Also, there should be a distance between channel and implant
-        # TODO: The pimplant_to_nimplant is new. Probably not in other techs
+        # The pimplant_to_nimplant is new.
+        pimp_to_nimp = 0
+        imp_to_active = 0
+        try:
+            pimp_to_nimp = drc("pimplant_to_nimplant")
+            imp_to_active = drc("implant_to_active")
+        except:
+            pass
         contact_xoffset = nmos_pos.x + nmos.active_width \
                           + max(self.active_space,
-                                2*drc("implant_enclose_active") + drc("pimplant_to_nimplant"),
-                                drc("implant_to_active") + drc("implant_enclose_active"))
+                                2*drc("implant_enclose_active") + pimp_to_nimp,
+                                imp_to_active + drc("implant_enclose_active"))
         # Must be at least an well enclosure of active up
         # from the bottom of the well
         contact_yoffset = max(nmos_pos.y,

--- a/compiler/pgates/pnand3.py
+++ b/compiler/pgates/pnand3.py
@@ -13,6 +13,7 @@ import logical_effort
 from sram_factory import factory
 import contact
 from tech import cell_properties as cell_props
+from globals import OPTS
 
 
 class pnand3(pgate.pgate):
@@ -225,6 +226,10 @@ class pnand3(pgate.pgate):
         self.inputA_yoffset = max(active_contact_to_poly_contact,
                                   active_to_poly_contact,
                                   active_to_poly_contact2)
+
+        # TODO: There has to be a better way for this
+        if OPTS.tech_name == "tsmc18":
+            self.inputA_yoffset += self.m1_pitch
 
         apin = self.route_input_gate(self.pmos1_inst,
                                      self.nmos1_inst,

--- a/compiler/pgates/pnand4.py
+++ b/compiler/pgates/pnand4.py
@@ -13,6 +13,7 @@ import logical_effort
 from sram_factory import factory
 import contact
 from tech import cell_properties as cell_props
+from globals import OPTS
 
 
 class pnand4(pgate.pgate):
@@ -240,6 +241,10 @@ class pnand4(pgate.pgate):
         self.inputA_yoffset = max(active_contact_to_poly_contact,
                                   active_to_poly_contact,
                                   active_to_poly_contact2)
+
+        # TODO: There has to be a better way for this
+        if OPTS.tech_name == "tsmc18":
+            self.inputA_yoffset += self.m1_pitch
 
         apin = self.route_input_gate(self.pmos1_inst,
                                      self.nmos1_inst,

--- a/compiler/pgates/ptx.py
+++ b/compiler/pgates/ptx.py
@@ -149,6 +149,12 @@ class ptx(design.design):
         self.spice_device = main_str + area_str
         self.spice.append("\n* spice ptx " + self.spice_device)
 
+        # For LVS devices, the name may change
+        try:
+            from tech import lvs_spice
+        except:
+            lvs_spice = spice
+
         if cell_props.ptx.model_is_subckt and OPTS.lvs_exe and OPTS.lvs_exe[0] == "calibre":
             # sky130 requires mult parameter too. It is not the same as m, but I don't understand it.
             # self.lvs_device = "X{{0}} {{1}} {0} m={1} w={2} l={3} mult=1".format(spice[self.tx_type],
@@ -163,12 +169,12 @@ class ptx(design.design):
                                                                                  drc("minwidth_poly"))
         elif cell_props.ptx.model_is_subckt:
             # sky130 requires mult parameter too
-            self.lvs_device = "X{{0}} {{1}} {0} m={1} w={2}u l={3}u".format(spice[self.tx_type],
+            self.lvs_device = "X{{0}} {{1}} {0} m={1} w={2}u l={3}u".format(lvs_spice[self.tx_type],
                                                                             self.mults,
                                                                             self.tx_width,
                                                                             drc("minwidth_poly"))
         else:
-            self.lvs_device = "M{{0}} {{1}} {0} m={1} w={2}u l={3}u ".format(spice[self.tx_type],
+            self.lvs_device = "M{{0}} {{1}} {0} m={1} w={2}u l={3}u ".format(lvs_spice[self.tx_type],
                                                                              self.mults,
                                                                              self.tx_width,
                                                                              drc("minwidth_poly"))

--- a/compiler/pgates/ptx.py
+++ b/compiler/pgates/ptx.py
@@ -370,11 +370,12 @@ class ptx(design.design):
         # If the implant must enclose the active, shift offset
         # and increase width/height
         enclose_width = self.implant_enclose_active
-        enclose_offset = [enclose_width] * 2
+        enclose_height = max(self.implant_enclose_active, drc("implant_to_channel"))
+        enclose_offset = vector(enclose_width, enclose_height)
         self.implant = self.add_rect(layer="{}implant".format(self.implant_type),
                                      offset=self.active_offset - enclose_offset,
                                      width=self.active_width + 2 * enclose_width,
-                                     height=self.active_height + 2 * enclose_width)
+                                     height=self.active_height + 2 * enclose_height)
 
     def add_well_implant(self):
         """


### PR DESCRIPTION
List of changes:

hierarchy_layout.py: 
- Support for the minimal areas. Only activated to "tsmc18" strings in the tech_name.

pgate.py: 
- Whenever a port is created in any gate, it does not put the minimum area requirements. Seems like is assumed to be routed afterward, but if a further via comes, the via-stack violates the minarea. Added only to support tsmc18, but can support any if remove the "if"
- Minimum area for nwell and pwell bulk contacts. Just adds center-vertically additional area with its respective implementations. (Only for tsmc18)
- Avoid the overlap of pimp and nmos when adding a n/pwell bulk connection. New DRC added for this purpose (pimplant_to_nimplant / implant_to_active, works for all techs)
- Fixes for extending implants in gates, taking the implant_enclose_active.

pre-charge.py:
- Same bulk connections fixed also in the pre-charge.py module. This does not work with pgate.py.
- Implant expansion (tsmc18 only)

column-mux.py:
- Same bulk connections fixed also in the column-mux.py module. This does not work with pgate.py.

ptx.py:
- Inclusion of enclose_width and enclose_height, which are different if the "implant_to_channel" is different than "implant_enclose_active".
- Spice LVS detection inside the "lvs_spice" tech variable. Auto-detectable if not defined in the other techs.

pand[2/3/4].py:
- Expansion of the implementation only in tsmc18. There is original no need for the other techs, as the imp can be with the active.

pnand[3/4].py:
- A hackish to displace the ports. Added one m1 pitch only in case of tsmc18.

This source passes the scmos tests using magic + netgen. No tests for freepdk45 were done.

Thank you very much for considering this pull request.