### PR TITLE
README: Fix example in Basic Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ nominal_corner_only = True
 # Process corners to characterize
 # process_corners = ["SS", "TT", "FF"]
 # Voltage corners to characterize
-# supply_voltages = [ 3.0, 3.3, 3.5 ]
+# supply_voltages = [3.0, 3.3, 3.5]
 # Temperature corners to characterize
-# temperatures = [ 0, 25 100]
+# temperatures = [0, 25, 100]
 
 # Output directory for the results
 output_path = "temp"


### PR DESCRIPTION
Add missing comma and remove whitespaces before and after the first
and last element in array.

Signed-off-by: Daniel Schultz <daniel.schultz@aesc-silicon.de>