### PR TITLE
Remove SRAM_LIBRARY folder when cleanning up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ $(INSTALL_BASE)/sp_lib: $(filter-out %.$(SPICE_LVS_SUFFIX) %.$(SPICE_CALIBRE_SUF
 	@echo
 
 clean:
-	rm -f $(SRAM_LIBRARY)
+	rm -rf $(SRAM_LIBRARY)
 	rm -f $(INSTALL_BASE)/tech/.magicrc
 	rm -f $(INSTALL_BASE)/mag_lib/.magicrc
 	rm -f $(INSTALL_BASE)/lef_lib/.magicrc


### PR DESCRIPTION
Thanks for building and maintaining this amazing tool!

I just start to learning about the open source ASIC toolchain and ASIC in general. Seems like in the starter guide, we haven't mentioned that we need to `make` first for file generation. It is not hard to figure out, but I believe adding it would make the process more beginner friendly. 

Thanks!