### PR TITLE
Add nand4_leakage to sky130

### DIFF
--- a/technology/sky130/tech/tech.py
+++ b/technology/sky130/tech/tech.py
@@ -741,6 +741,7 @@ spice["bitcell_leakage"] = 1     # Leakage power of a single bitcell in nW
 spice["inv_leakage"] = 1         # Leakage power of inverter in nW
 spice["nand2_leakage"] = 1       # Leakage power of 2-input nand in nW
 spice["nand3_leakage"] = 1       # Leakage power of 3-input nand in nW
+spice["nand4_leakage"] = 1       # Leakage power of 4-input nand in nW
 spice["nor2_leakage"] = 1        # Leakage power of 2-input nor in nW
 spice["dff_leakage"] = 1         # Leakage power of flop in nW
 


### PR DESCRIPTION
Thanks for this project! I was trying to build SRAMs using sky130 using the following configuration:

```
#Truncated
word_size = 8
num_words = 4096
write_size = 8
num_rw_ports = 0
num_r_ports = 1
num_w_ports = 1
```

It generates the following error:
```
Traceback (most recent call last):                                              
  File "/scratch/ja/skywater/OpenRAM/compiler/openram.py", line 81, in <module> 
    s.save()                                                                    
  File "/scratch/ja/skywater/OpenRAM/compiler/sram/sram.py", line 146, in save  
    lib(out_dir=OPTS.output_path, sram=self.s, sp_file=sp_file)                 
  File "/scratch/ja/skywater/OpenRAM/compiler/characterizer/lib.py", line 46, in __init__
    self.characterize_corners()                                                 
  File "/scratch/ja/skywater/OpenRAM/compiler/characterizer/lib.py", line 163, in characterize_corners
    self.characterize()                                                         
  File "/scratch/ja/skywater/OpenRAM/compiler/characterizer/lib.py", line 175, in characterize
    self.compute_delay()                                                        
  File "/scratch/ja/skywater/OpenRAM/compiler/characterizer/lib.py", line 645, in compute_delay
    char_results = m.get_lib_values(self.load_slews)
  File "/scratch/ja/skywater/OpenRAM/compiler/characterizer/elmore.py", line 63, in get_lib_values
    power = self.analytical_power(load_slews)
  File "/scratch/ja/skywater/OpenRAM/compiler/characterizer/elmore.py", line 103, in analytical_power
    power = self.sram.analytical_power(self.corner, load)
  File "/scratch/ja/skywater/OpenRAM/compiler/base/design.py", line 324, in analytical_power
    total_module_power += inst.mod.analytical_power(corner, load)
  File "/scratch/ja/skywater/OpenRAM/compiler/base/design.py", line 324, in analytical_power
    total_module_power += inst.mod.analytical_power(corner, load)                                           
  File "/scratch/ja/skywater/OpenRAM/compiler/base/design.py", line 324, in analytical_power
    total_module_power += inst.mod.analytical_power(corner, load)                                 
  [Previous line repeated 2 more times]
  File "/scratch/ja/skywater/OpenRAM/compiler/pgates/pnand4.py", line 329, in analytical_power
    power_leak = spice["nand4_leakage"]
KeyError: 'nand4_leakage' 
```

Seems like the same issue as #97 with a simple fix.