### PR TITLE
Validate tech_name param in compiler/globals.py

### DIFF
--- a/compiler/globals.py
+++ b/compiler/globals.py
@@ -567,7 +567,7 @@ def import_tech():
     # Validate tech_name param
     techname_lower = OPTS.tech_name.lower()
     if (techname_lower is None) or (techname_lower!="sky130" and techname_lower!="scn3m_subm" and techname_lower!="scn4m_subm" and techname_lower!="freepdk45") :
-        debug.error("tech_name in config file should be sky130|scn3m_subm|scn4m_subm")
+        debug.error("tech_name in config file should be sky130|scn3m_subm|scn4m_subm|freepdk45")
         quit()
         
     # Import the tech

--- a/compiler/globals.py
+++ b/compiler/globals.py
@@ -558,16 +558,22 @@ def import_tech():
     openram.OPENRAM_TECH = OPENRAM_TECH
 
     # Add all of the paths
+    tech_found = None
     for tech_path in OPENRAM_TECH.split(":"):
         debug.check(os.path.isdir(tech_path),
                     "$OPENRAM_TECH does not exist: {}".format(tech_path))
         sys.path.append(tech_path)
         debug.info(1, "Adding technology path: {}".format(tech_path))
 
-    # Validate tech_name param
-    techname_lower = OPTS.tech_name.lower()
-    if (techname_lower is None) or (techname_lower!="sky130" and techname_lower!="scn3me_subm" and techname_lower!="scn4m_subm" and techname_lower!="freepdk45") :
-        debug.error("tech_name in config file should be sky130|scn3me_subm|scn4m_subm|freepdk45")
+        # List all tech dirs in that path and check if we can find the tech_name inside
+        for tech_dir in os.listdir(tech_path):
+            if tech_dir==OPTS.tech_name :
+                tech_found = tech_dir
+                break;
+                
+	# If the tech_name param specified by the user is not present in the technology folder, emit an error and quit
+    if (tech_found is None):
+        debug.error(f"You specified \'tech_name={OPTS.tech_name}\' in your config file, but that technology is not present in the technologies folder!")
         quit()
         
     # Import the tech

--- a/compiler/globals.py
+++ b/compiler/globals.py
@@ -571,7 +571,7 @@ def import_tech():
                 tech_found = tech_dir
                 break;
                 
-	# If the tech_name param specified by the user is not present in the technology folder, emit an error and quit
+    # If the tech_name param specified by the user is not present in the technology folder, emit an error and quit
     if (tech_found is None):
         debug.error(f"You specified \'tech_name={OPTS.tech_name}\' in your config file, but that technology is not present in the technologies folder!")
         quit()

--- a/compiler/globals.py
+++ b/compiler/globals.py
@@ -566,8 +566,8 @@ def import_tech():
 
     # Validate tech_name param
     techname_lower = OPTS.tech_name.lower()
-    if (techname_lower is None) or (techname_lower!="sky130" and techname_lower!="scn3m_subm" and techname_lower!="scn4m_subm" and techname_lower!="freepdk45") :
-        debug.error("tech_name in config file should be sky130|scn3m_subm|scn4m_subm|freepdk45")
+    if (techname_lower is None) or (techname_lower!="sky130" and techname_lower!="scn3me_subm" and techname_lower!="scn4m_subm" and techname_lower!="freepdk45") :
+        debug.error("tech_name in config file should be sky130|scn3me_subm|scn4m_subm|freepdk45")
         quit()
         
     # Import the tech

--- a/compiler/globals.py
+++ b/compiler/globals.py
@@ -566,7 +566,7 @@ def import_tech():
 
     # Validate tech_name param
     techname_lower = OPTS.tech_name.lower()
-    if (techname_lower is None) or (techname_lower!="sky130" and techname_lower!="scn3m_subm" and techname_lower!="scn4m_subm") :
+    if (techname_lower is None) or (techname_lower!="sky130" and techname_lower!="scn3m_subm" and techname_lower!="scn4m_subm" and techname_lower!="freepdk45") :
         debug.error("tech_name in config file should be sky130|scn3m_subm|scn4m_subm")
         quit()
         

--- a/compiler/globals.py
+++ b/compiler/globals.py
@@ -564,6 +564,12 @@ def import_tech():
         sys.path.append(tech_path)
         debug.info(1, "Adding technology path: {}".format(tech_path))
 
+    # Validate tech_name param
+    techname_lower = OPTS.tech_name.lower()
+    if (techname_lower is None) or (techname_lower!="sky130" and techname_lower!="scn3m_subm" and techname_lower!="scn4m_subm") :
+        debug.error("tech_name in config file should be sky130|scn3m_subm|scn4m_subm")
+        quit()
+        
     # Import the tech
     try:
         tech_mod = __import__(OPTS.tech_name)


### PR DESCRIPTION
We need to pre-validate the tech_name param in the config file or python will comply with a non-very-descriptive message that can confuse the user about where's the problem.