### PR TITLE
Add LEF output for ROM

### DIFF
--- a/compiler/modules/rom_bank.py
+++ b/compiler/modules/rom_bank.py
@@ -11,13 +11,14 @@ from math import ceil, log
 from openram.base import vector
 from openram.base import design
 from openram.base import rom_verilog
+from openram.base import lef
 from openram import OPTS, print_time
 from openram.sram_factory import factory
 from openram.tech import spice
 from openram.tech import drc, layer, parameter
 
 
-class rom_bank(design,rom_verilog):
+class rom_bank(design, rom_verilog, lef):
 
     """
     Rom data bank with row and column decoder + control logic
@@ -27,6 +28,7 @@ class rom_bank(design,rom_verilog):
 
     def __init__(self, name, rom_config):
         super().__init__(name=name)
+        lef.__init__(self, ["m1", "m2", "m3", "m4"])
         self.rom_config = rom_config
         rom_config.set_local_config(self)
 

--- a/compiler/rom.py
+++ b/compiler/rom.py
@@ -59,6 +59,9 @@ class rom():
     def sp_write(self, name, lvs=False, trim=False):
         self.r.sp_write(name, lvs, trim)
 
+    def lef_write(self, name):
+        self.r.lef_write(name)
+
     def gds_write(self, name):
         self.r.gds_write(name)
 
@@ -105,6 +108,13 @@ class rom():
                                         final_verification=True,
                                         output_path=OPTS.output_path)
             print_time("GDS", datetime.datetime.now(), start_time)
+
+            # Create a LEF physical model
+            start_time = datetime.datetime.now()
+            lefname = OPTS.output_path + self.r.name + ".lef"
+            debug.print_raw("LEF: Writing to {0}".format(lefname))
+            self.lef_write(lefname)
+            print_time("LEF", datetime.datetime.now(), start_time)
 
         # Save the LVS file
         start_time = datetime.datetime.now()

--- a/rom_compiler.py
+++ b/rom_compiler.py
@@ -51,7 +51,7 @@ openram.print_time("Start", start_time)
 output_extensions = [ "sp", "v"]
 # Only output lef/gds if back-end
 if not OPTS.netlist_only:
-    output_extensions.extend(["gds"])
+    output_extensions.extend(["lef", "gds"])
 
 output_files = ["{0}{1}.{2}".format(OPTS.output_path,
                                     OPTS.output_name, x)


### PR DESCRIPTION
This change enables LEF writing for ROMs. There was not much to do, so I hope this wasn't omitted for a reason. But together with this PR and some changes to the Verilog model, I am able to use the ROMs together with OpenLane.