### PR TITLE
Fix wire capacitance unit in sky130, gf180

### DIFF
--- a/compiler/base/wire_spice_model.py
+++ b/compiler/base/wire_spice_model.py
@@ -18,8 +18,7 @@ class wire_spice_model():
     def cal_wire_c(self, wire_length, wire_width):
         from openram.tech import spice
         # Convert the F/um^2 to fF/um^2 then multiple by width and length
-        # FIXME: shouldn't it be 1e15?
-        total_c = (spice["wire_unit_c"]*1e12) * wire_length * wire_width
+        total_c = (spice["wire_unit_c"]*1e15) * wire_length * wire_width
         wire_c = total_c / self.lump_num
         return wire_c
 

--- a/technology/gf180mcu/tech/tech.py
+++ b/technology/gf180mcu/tech/tech.py
@@ -427,15 +427,15 @@ spice["temperatures"] = [0, 25, 100] # Temperature corners (celcius)
 spice["nom_temperature"] = 25        # Nominal temperature (celcius)
 
 # analytical delay parameters
-spice["nom_threshold"] = 0.49     # Typical Threshold voltage in Volts
-spice["wire_unit_r"] = 0.125     # Unit wire resistance in ohms/square
-spice["wire_unit_c"] = 0.134     # Unit wire capacitance ff/um^2
-spice["min_tx_drain_c"] = 0.7    # Minimum transistor drain capacitance in ff
-spice["min_tx_gate_c"] = 0.2     # Minimum transistor gate capacitance in ff
-spice["dff_setup"] = 102.5391    # DFF setup time in ps
-spice["dff_hold"] = -56          # DFF hold time in ps
-spice["dff_in_cap"] = 6.89       # Input capacitance (D) [Femto-farad]
-spice["dff_out_cap"] = 6.89      # Output capacitance (Q) [Femto-farad]
+spice["nom_threshold"] = 0.49       # Typical Threshold voltage in Volts
+spice["wire_unit_r"] = 0.125        # Unit wire resistance in ohms/square
+spice["wire_unit_c"] = 0.134e-15    # Unit wire capacitance F/um^2
+spice["min_tx_drain_c"] = 0.7       # Minimum transistor drain capacitance in ff
+spice["min_tx_gate_c"] = 0.2        # Minimum transistor gate capacitance in ff
+spice["dff_setup"] = 102.5391       # DFF setup time in ps
+spice["dff_hold"] = -56             # DFF hold time in ps
+spice["dff_in_cap"] = 6.89          # Input capacitance (D) [Femto-farad]
+spice["dff_out_cap"] = 6.89         # Output capacitance (Q) [Femto-farad]
 
 # analytical power parameters, many values are temporary
 spice["bitcell_leakage"] = 1     # Leakage power of a single bitcell in nW

--- a/technology/scn3me_subm/tech/tech.py
+++ b/technology/scn3me_subm/tech/tech.py
@@ -257,16 +257,16 @@ spice["temperatures"] = [0, 25, 100]  # Temperature corners (celcius)
 spice["nom_temperature"] = 25        # Nominal temperature (celcius)
 
 # analytical delay parameters
-spice["nom_threshold"] = 1.3   # Typical Threshold voltage in Volts
+spice["nom_threshold"] = 1.3        # Typical Threshold voltage in Volts
 # FIXME: These need to be updated for SCMOS, they are copied from FreePDK45.
-spice["wire_unit_r"] = 0.075    # Unit wire resistance in ohms/square
-spice["wire_unit_c"] = 0.64     # Unit wire capacitance ff/um^2
-spice["min_tx_drain_c"] = 0.7   # Minimum transistor drain capacitance in ff
-spice["min_tx_gate_c"] = 0.1    # Minimum transistor gate capacitance in ff
-spice["dff_setup"] = 9        # DFF setup time in ps
-spice["dff_hold"] = 1         # DFF hold time in ps
-spice["dff_in_cap"] = 9.8242  # Input capacitance (D) [Femto-farad]
-spice["dff_out_cap"] = 2       # Output capacitance (Q) [Femto-farad]
+spice["wire_unit_r"] = 0.075        # Unit wire resistance in ohms/square
+spice["wire_unit_c"] = 0.64e-15     # Unit wire capacitance F/um^2
+spice["min_tx_drain_c"] = 0.7       # Minimum transistor drain capacitance in ff
+spice["min_tx_gate_c"] = 0.1        # Minimum transistor gate capacitance in ff
+spice["dff_setup"] = 9              # DFF setup time in ps
+spice["dff_hold"] = 1               # DFF hold time in ps
+spice["dff_in_cap"] = 9.8242        # Input capacitance (D) [Femto-farad]
+spice["dff_out_cap"] = 2            # Output capacitance (Q) [Femto-farad]
 
 # analytical power parameters, many values are temporary
 spice["bitcell_leakage"] = 1     # Leakage power of a single bitcell in nW

--- a/technology/sky130/tech/tech.py
+++ b/technology/sky130/tech/tech.py
@@ -731,15 +731,15 @@ spice["temperatures"] = [0, 25, 100] # Temperature corners (celcius)
 spice["nom_temperature"] = 25        # Nominal temperature (celcius)
 
 # analytical delay parameters
-spice["nom_threshold"] = 0.49     # Typical Threshold voltage in Volts
-spice["wire_unit_r"] = 0.125     # Unit wire resistance in ohms/square
-spice["wire_unit_c"] = 0.134     # Unit wire capacitance ff/um^2
-spice["min_tx_drain_c"] = 0.7    # Minimum transistor drain capacitance in ff
-spice["min_tx_gate_c"] = 0.2     # Minimum transistor gate capacitance in ff
-spice["dff_setup"] = 102.5391    # DFF setup time in ps
-spice["dff_hold"] = -56          # DFF hold time in ps
-spice["dff_in_cap"] = 6.89       # Input capacitance (D) [Femto-farad]
-spice["dff_out_cap"] = 6.89      # Output capacitance (Q) [Femto-farad]
+spice["nom_threshold"] = 0.49       # Typical Threshold voltage in Volts
+spice["wire_unit_r"] = 0.125        # Unit wire resistance in ohms/square
+spice["wire_unit_c"] = 0.134e-15    # Unit wire capacitance F/um^2
+spice["min_tx_drain_c"] = 0.7       # Minimum transistor drain capacitance in ff
+spice["min_tx_gate_c"] = 0.2        # Minimum transistor gate capacitance in ff
+spice["dff_setup"] = 102.5391       # DFF setup time in ps
+spice["dff_hold"] = -56             # DFF hold time in ps
+spice["dff_in_cap"] = 6.89          # Input capacitance (D) [Femto-farad]
+spice["dff_out_cap"] = 6.89         # Output capacitance (Q) [Femto-farad]
 
 # analytical power parameters, many values are temporary
 spice["bitcell_leakage"] = 1     # Leakage power of a single bitcell in nW


### PR DESCRIPTION
The `wire_spice_model()` expects `spice["wire_unit_c"]` in Farads per micrometer squared (F/um²). This is given correctly in the FreePDK45 tech but incorrectly in other technologies. This leads to a huge overestimation of wire capacitance in those technologies, leading to incorrect power values.

Before this patch, the liberty files would give values like this for the rise/fall power:
```
    pin(clk1){
        clock             : true;
        direction  : input; 
        capacitance : 0.006889999999999999;  
        internal_power(){
            when : "!csb1"; 
            rise_power(scalar){
                values("5.075574e+10");
            }
[...]                
```