### PR TITLE
Add ROM config for gf180mcu

### DIFF
--- a/compiler/modules/rom_bank.py
+++ b/compiler/modules/rom_bank.py
@@ -15,7 +15,7 @@ from openram.base import lef
 from openram import OPTS, print_time
 from openram.sram_factory import factory
 from openram.tech import spice
-from openram.tech import drc, layer, parameter
+from openram.tech import drc, layer, parameter, lef_rom_interconnect
 
 
 class rom_bank(design, rom_verilog, lef):
@@ -28,7 +28,7 @@ class rom_bank(design, rom_verilog, lef):
 
     def __init__(self, name, rom_config):
         super().__init__(name=name)
-        lef.__init__(self, ["m1", "m2", "m3", "m4"])
+        lef.__init__(self, lef_rom_interconnect)
         self.rom_config = rom_config
         rom_config.set_local_config(self)
 

--- a/compiler/rom.py
+++ b/compiler/rom.py
@@ -152,6 +152,7 @@ class rom():
         start_time = datetime.datetime.now()
         from shutil import copyfile
         copyfile(OPTS.config_file, OPTS.output_path + OPTS.output_name + '.py')
+        os.makedirs(os.path.dirname(OPTS.output_path + self.rom_data), exist_ok=True)
         copyfile(self.rom_data, OPTS.output_path + self.rom_data)
         debug.print_raw("Config: Writing to {0}".format(OPTS.output_path + OPTS.output_name + '.py'))
         print_time("Config", datetime.datetime.now(), start_time)

--- a/docs/source/basic_setup.md
+++ b/docs/source/basic_setup.md
@@ -147,11 +147,13 @@ OpenRAM library.
 
 OpenRAM currently **does not** support gf180mcu for SRAM generation. However ROM generation for gf180mcu is supported as an experimental feature.
 
-It is not necessary to install the gf180mcu PDK, as all necessary files are already in the git repository under `technology/gf180mcu/`.
+To install gf180mcuD, you can run:
 
-If you still want to install the PDK, you can run `make gf180mcu-pdk`.
+```
+cd $HOME/OpenRAM
+make gf180mcu-pdk
+```
 
 [SCMOS]:    https://www.mosis.com/files/scmos/scmos.pdf
 [FreePDK45]: https://www.eda.ncsu.edu/wiki/FreePDK45:Contents
 [Sky130]:   https://github.com/google/skywater-pdk-libs-sky130_fd_bd_sram.git
-

--- a/macros/Makefile
+++ b/macros/Makefile
@@ -50,6 +50,7 @@ WORKING_ROM_STAMPS=$(filter-out $(addsuffix .ok, $(BROKEN)), $(ROM_STAMPS))
 
 EXAMPLE_STAMPS=$(filter example%, $(WORKING_SRAM_STAMPS)) $(filter example%, $(WORKING_ROM_STAMPS))
 SKY130_STAMPS=$(filter sky130%, $(WORKING_SRAM_STAMPS)) $(filter sky130%, $(WORKING_ROM_STAMPS))
+GF180MCU_STAMPS=$(filter gf180mcu%, $(WORKING_SRAM_STAMPS)) $(filter gf180mcu%, $(WORKING_ROM_STAMPS))
 FREEPDK45_STAMPS=$(filter freepdk45%, $(WORKING_STAMPS)) $(filter freepdk45%, $(WORKING_ROM_STAMPS))
 SCN4M_SUBM_STAMPS=$(filter scn4m_subm%, $(WORKING_STAMPS)) $(filter scn4m_subm%, $(WORKING_ROM_STAMPS))
 

--- a/macros/rom_configs/gf180mcu_rom_1kbyte.py
+++ b/macros/rom_configs/gf180mcu_rom_1kbyte.py
@@ -1,0 +1,20 @@
+# See LICENSE for licensing information.
+#
+# Copyright (c) 2016-2023 Regents of the University of California and The Board
+# of Regents for the Oklahoma Agricultural and Mechanical College
+# (acting for and on behalf of Oklahoma State University)
+# All rights reserved.
+#
+
+word_size = 1
+
+check_lvsdrc = True
+
+rom_data = "rom_configs/example_1kbyte.bin"
+data_type = "bin"
+
+output_name = "rom_1kbyte"
+output_path = "macro/{output_name}".format(**locals())
+
+import os
+exec(open(os.path.join(os.path.dirname(__file__), 'gf180mcu_rom_common.py')).read())

--- a/macros/rom_configs/gf180mcu_rom_common.py
+++ b/macros/rom_configs/gf180mcu_rom_common.py
@@ -9,6 +9,6 @@ tech_name = "gf180mcu"
 nominal_corner_only = True
 
 route_supplies = "ring"
-check_lvsdrc = True
-# check_lvsdrc = False
+# check_lvsdrc = True
+check_lvsdrc = False
 

--- a/macros/rom_configs/gf180mcu_rom_common.py
+++ b/macros/rom_configs/gf180mcu_rom_common.py
@@ -1,0 +1,14 @@
+# See LICENSE for licensing information.
+#
+# Copyright (c) 2016-2023 Regents of the University of California and The Board
+# of Regents for the Oklahoma Agricultural and Mechanical College
+# (acting for and on behalf of Oklahoma State University)
+# All rights reserved.
+#
+tech_name = "gf180mcu"
+nominal_corner_only = True
+
+route_supplies = "ring"
+check_lvsdrc = True
+# check_lvsdrc = False
+

--- a/technology/gf180mcu/tech/tech.py
+++ b/technology/gf180mcu/tech/tech.py
@@ -97,6 +97,7 @@ m2_stack = ("m2", "via2", "m3")
 m3_stack = ("m3", "via3", "m4")
 m4_stack = ("m4", "via4", "m5")
 
+lef_rom_interconnect = ["m1", "m2", "m3", "m4", "m5"]
 
 layer_indices = {"poly": 0,
                  "active": 0,
@@ -182,6 +183,8 @@ layer_names["via2"]    = "via2"
 layer_names["m3"]      = "metal3"
 layer_names["via3"]    = "via3"
 layer_names["m4"]      = "metal4"
+layer_names["via4"]    = "via4"
+layer_names["m5"]      = "metal5"
 layer_names["text"]    = "text"
 layer_names["mem"]     = "SramCore"
 layer_names["boundary"]= "boundary"

--- a/technology/sky130/tech/tech.py
+++ b/technology/sky130/tech/tech.py
@@ -330,6 +330,8 @@ m2_stack = ("m2", "via2", "m3")
 m3_stack = ("m3", "via3", "m4")
 m4_stack = ("m4", "via4", "m5")
 
+lef_rom_interconnect = ["m1", "m2", "m3", "m4"]
+
 layer_indices = {"poly": 0,
                  "active": 0,
                  "nwell": 0,


### PR DESCRIPTION
Since OpenROM has experimental support for gf180mcuD, I think it would be useful to have a test to make sure it does not break in the future.

This PR adds one config for: `gf180mcu_rom_1kbyte`.

For now, I disabled `check_lvsdrc` for gf180mcu as it seems the magic version installed via conda is too old.
Maybe the tools/PDK versions that OpenRAM uses can be updated in the future.

Also, when writing rom_data, it makes sure that the output directory exists.

I created the variable `lef_rom_interconnect` to specify the metal layers for lef writing.
Maybe you know a better name for it ;)