### PR TITLE
Fix compatibility with numpy>=2.4.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ All unit tests should pass first.
 3. Clone your repository (or use an existing cloned copy if you've
    already done this once):
 ```
-  git clone https://github.com/<youruser>/oepnram.git
+  git clone https://github.com/<youruser>/openram.git
   cd openram
 ```
 

--- a/compiler/base/hierarchy_layout.py
+++ b/compiler/base/hierarchy_layout.py
@@ -1816,9 +1816,9 @@ class layout():
             # The boundary will determine the limits to the size
             # of the routing grid
             boundary = layout.measureBoundary(top_name)
-            # These must be un-indexed to get rid of the matrix type
-            ll = vector(boundary[0][0], boundary[0][1])
-            ur = vector(boundary[1][0], boundary[1][1])
+            # These must be un-indexed to get rid of the numpy array type
+            ll = vector(boundary[0][0].item(), boundary[0][1].item())
+            ur = vector(boundary[1][0].item(), boundary[1][1].item())
         else:
             ll, ur = self.bbox
 


### PR DESCRIPTION
This fixes issue #279. Now able to use OpenRAM with latest numpy releases.