### PR TITLE
Attempt to fix LVS mismatch and SRAM creation with banks for sky130

### DIFF
--- a/compiler/characterizer/delay.py
+++ b/compiler/characterizer/delay.py
@@ -1388,11 +1388,15 @@ class delay(simulation):
     def calculate_inverse_address(self):
         """Determine dummy test address based on probe address and column mux size."""
 
-        # The inverse address needs to share the same bitlines as the probe address as the trimming will remove all other bitlines
+        # The inverse address needs to share the same bitlines as the probe address as the trimming will remove all other bitlines.
         # This is only an issue when there is a column mux and the address maps to different bitlines.
         column_addr = self.get_column_addr() # do not invert this part
         inverse_address = ""
-        for c in self.probe_address[self.sram.col_addr_size:]: # invert everything else
+        if self.sram.col_addr_size > 0:
+            row_address = self.probe_address[:-self.sram.col_addr_size]
+        else:
+            row_address = self.probe_address
+        for c in row_address: # invert row bits only
             if c=="0":
                 inverse_address += "1"
             elif c=="1":

--- a/compiler/characterizer/simulation.py
+++ b/compiler/characterizer/simulation.py
@@ -126,8 +126,10 @@ class simulation():
     def get_data_bit_column_number(self, probe_address, probe_data):
         """Calculates bitline column number of data bit under test using bit position and mux size"""
 
-        if self.sram.col_addr_size>0:
-            col_address = int(probe_address[0:self.sram.col_addr_size], 2)
+        # Address pins are ordered a*_0 ... a*_N, where a*_0 is the LSB.
+        # So the column mux select bits are the rightmost bits in the binary address string.
+        if self.sram.col_addr_size > 0:
+            col_address = int(probe_address[-self.sram.col_addr_size:], 2)
         else:
             col_address = 0
         bl_column = int(self.sram.words_per_row * probe_data + col_address)
@@ -136,7 +138,11 @@ class simulation():
     def get_address_row_number(self, probe_address):
         """Calculates wordline row number of data bit under test using address and column mux size"""
 
-        return int(probe_address[self.sram.col_addr_size:], 2)
+        if self.sram.col_addr_size > 0:
+            row_address = probe_address[:-self.sram.col_addr_size]
+        else:
+            row_address = probe_address
+        return int(row_address, 2) if row_address else 0
 
     def add_control_one_port(self, port, op):
         """Appends control signals for operation to a given port"""
@@ -484,7 +490,9 @@ class simulation():
 
     def get_column_addr(self):
         """Returns column address of probe bit"""
-        return self.probe_address[:self.sram.col_addr_size]
+        if self.sram.col_addr_size == 0:
+            return ""
+        return self.probe_address[-self.sram.col_addr_size:]
 
     def add_graph_exclusions(self):
         """

--- a/compiler/characterizer/trim_spice.py
+++ b/compiler/characterizer/trim_spice.py
@@ -56,12 +56,15 @@ class trim_spice():
         # Always start fresh if we do multiple reductions
         self.sp_buffer = self.spice
 
-        # Split up the address and convert to an int
-        wl_address = int(address[self.col_addr_size:], 2)
+        # Address pins are ordered with bit 0 as LSB, so mux column bits
+        # are the rightmost bits in the binary address string.
         if self.col_addr_size > 0:
-            col_address = int(address[0:self.col_addr_size], 2)
+            row_address = address[:-self.col_addr_size]
+            col_address = int(address[-self.col_addr_size:], 2)
         else:
+            row_address = address
             col_address = 0
+        wl_address = int(row_address, 2) if row_address else 0
 
         # 1. Keep cells in the bitcell array based on WL and BL
         wl_name = "wl_{}".format(wl_address)

--- a/technology/sky130/custom/sky130_bitcell_base_array.py
+++ b/technology/sky130/custom/sky130_bitcell_base_array.py
@@ -100,14 +100,15 @@ class sky130_bitcell_base_array(bitcell_base_array):
         strap_pins = []
         for port in self.all_ports:
             strap_pins.extend([x for x in self.get_bitline_names(port) if "bl" in x and x.endswith("_{0}".format(col))])
-        strap_pins.extend(["vdd", "gnd"])
         for port in self.all_ports:
             strap_pins.extend([x for x in self.get_bitline_names(port) if "br" in x and x.endswith("_{0}".format(col))])
+        # col_cap_1port_bitcell port order:
+        # [bl, br, vdd, gnd, vpb, vnb, gate]
+        strap_pins.extend(["vdd", "gnd", "vdd", "gnd"])
         if row == 0:
-            strap_pins.extend(["top_gate"])
+            strap_pins.append("top_gate")
         else:
-            strap_pins.extend(["bot_gate"])
-        strap_pins.extend(["vdd", "gnd"])
+            strap_pins.append("bot_gate")
         return strap_pins
 
     def get_row_cap_pins(self, row, col):

--- a/technology/sky130/custom/sky130_col_cap_array.py
+++ b/technology/sky130/custom/sky130_col_cap_array.py
@@ -75,12 +75,12 @@ class sky130_col_cap_array(sky130_bitcell_base_array):
                 row_layout.append(self.colend1)
                 self.cell_inst[col]=self.add_inst(name=name, mod=self.colend1)
                 pins.append("fake_bl_{}".format(bitline))
-                pins.append("vdd")
-                pins.append("gnd")
                 pins.append("fake_br_{}".format(bitline))
-                pins.append("gate")
                 pins.append("vdd")
                 pins.append("gnd")
+                pins.append("vdd")
+                pins.append("gnd")
+                pins.append("gate")
                 bitline += 1
             elif col % 4 == 1:
                 row_layout.append(self.colend2)
@@ -92,12 +92,12 @@ class sky130_col_cap_array(sky130_bitcell_base_array):
                 row_layout.append(self.colend1)
                 self.cell_inst[col]=self.add_inst(name=name, mod=self.colend1)
                 pins.append("fake_bl_{}".format(bitline))
-                pins.append("vdd")
-                pins.append("gnd")
                 pins.append("fake_br_{}".format(bitline))
-                pins.append("gate")
                 pins.append("vdd")
                 pins.append("gnd")
+                pins.append("vdd")
+                pins.append("gnd")
+                pins.append("gate")
                 bitline += 1
             elif col % 4 ==3:
                 row_layout.append(self.colend2)


### PR DESCRIPTION
✅I have read `CONTRIBUTING.md` and am submitting this PR against the dev branch as requested.

### Background

While compiling the sky130 macro config sky130_sram_1kbyte_1rw_32x256_8, I ran:

`python sram_compiler.py macros/sram_configs/sky130_sram_1kbyte_1rw_32x256_8.py`

and consistently hit two known failures that have been discussed publicly:

LVS mismatch:

https://github.com/VLSIDA/OpenRAM/issues/217

Could not find bl net in timing paths:

https://github.com/VLSIDA/OpenRAM/issues/228

https://web.open-source-silicon.dev/t/27045118/hello-everyone-i-am-exploring-openram-and-want-to-create-a-r

a more detailed log is:

```
** Start: 02/19/2026 10:34:31 
Technology: sky130 
Total size: 8192 bits 
Word size: 32 
Words: 256 
Banks: 1 
Write size: 8 
RW ports: 1 
R-only ports: 0 
W-only ports: 0 
DRC/LVS/PEX is only run on the top-level design to save run-time (inline_lvsdrc=True to do inline checking). Characterization is disabled (using analytical delay models) (analytical_delay=False to simulate). Only generating nominal corner timing. Words per row: None 
Output files are: /home/rlin50/Projects/OpenRAM_Study/OpenRAM/macro/sky130_sram_1kbytes_1rw_32x256_8/sky130_sram_1kbytes_1rw_32x256_8.lvs 
/home/rlin50/Projects/OpenRAM_Study/OpenRAM/macro/sky130_sram_1kbytes_1rw_32x256_8/sky130_sram_1kbytes_1rw_32x256_8.sp 
/home/rlin50/Projects/OpenRAM_Study/OpenRAM/macro/sky130_sram_1kbytes_1rw_32x256_8/sky130_sram_1kbytes_1rw_32x256_8.v 
/home/rlin50/Projects/OpenRAM_Study/OpenRAM/macro/sky130_sram_1kbytes_1rw_32x256_8/sky130_sram_1kbytes_1rw_32x256_8.lib 
/home/rlin50/Projects/OpenRAM_Study/OpenRAM/macro/sky130_sram_1kbytes_1rw_32x256_8/sky130_sram_1kbytes_1rw_32x256_8.py 
/home/rlin50/Projects/OpenRAM_Study/OpenRAM/macro/sky130_sram_1kbytes_1rw_32x256_8/sky130_sram_1kbytes_1rw_32x256_8.html 
/home/rlin50/Projects/OpenRAM_Study/OpenRAM/macro/sky130_sram_1kbytes_1rw_32x256_8/sky130_sram_1kbytes_1rw_32x256_8.log 
/home/rlin50/Projects/OpenRAM_Study/OpenRAM/macro/sky130_sram_1kbytes_1rw_32x256_8/sky130_sram_1kbytes_1rw_32x256_8.lef 
/home/rlin50/Projects/OpenRAM_Study/OpenRAM/macro/sky130_sram_1kbytes_1rw_32x256_8/sky130_sram_1kbytes_1rw_32x256_8.gds 
** Submodules: 143.6 seconds 
** Placement: 0.0 seconds 
** Routing: 786.1 seconds 
ERROR: file magic.py: line 385: sky130_sram_1kbytes_1rw_32x256_8 LVS mismatch (results in /tmp/openram_rlin50_4126947_temp/sky130_sram_1kbytes_1rw_32x256_8.lvs.report) 
** Verification: 18140.4 seconds 
** SRAM creation: 19070.1 seconds 
SP: Writing to /home/rlin50/Projects/OpenRAM_Study/OpenRAM/macro/sky130_sram_1kbytes_1rw_32x256_8/sky130_sram_1kbytes_1rw_32x256_8.sp 
** Spice writing: 0.2 seconds DELAY: Writing stimulus... 
ERROR: file simulation.py: line 605: Could not find bl net in timing paths. Traceback (most recent call last): File "sram_compiler.py", line 76, in <module> s.save() File "/home/rlin50/Projects/OpenRAM_Study/OpenRAM/compiler/sram.py", line 130, in save d.analysis_init(probe_address, probe_data) File "/home/rlin50/Projects/OpenRAM_Study/OpenRAM/compiler/characterizer/delay.py", line 1288, in analysis_init self.set_internal_spice_names() File "/home/rlin50/Projects/OpenRAM_Study/OpenRAM/compiler/characterizer/simulation.py", line 520, in set_internal_spice_names bl_name_port, br_name_port = self.get_bl_name(self.graph.all_paths, port) File "/home/rlin50/Projects/OpenRAM_Study/OpenRAM/compiler/characterizer/simulation.py", line 624, in get_bl_name bl_names.append(self.get_alias_in_path(paths, int_net, cell_mod, exclude_set)) File "/home/rlin50/Projects/OpenRAM_Study/OpenRAM/compiler/characterizer/simulation.py", line 605, in get_alias_in_path debug.error("Could not find {} net in timing paths.".format(internal_net), 1) File "/home/rlin50/Projects/OpenRAM_Study/OpenRAM/compiler/debug.py", line 48, in error assert return_value == 0 AssertionError
```

### Root causes ~~maybe~~

The LVS mismatch is driven by a sky130 col_cap / related array pin-order / connection-order mismatch (i.e., instance connection order does not match the expected port order), which causes top-level matching to fail.

The characterization failure is caused by the address bit-order assumption used by the characterizer did not match the generated netlist, leading to wrong probe row/col selection and thus missing BL paths.

### What this PR changes

1. Align col_cap / bitcell base array port ordering with the actual instance connection order so that LVS top-level matching succeeds for this macro.
Affected files:
`technology/sky130/sky130_bitcell_base_array.py`
`technology/sky130/sky130_col_cap_array.py`

2. Fix address bit-order parsing used by the characterizer so probe row/col selection matches the generated netlist conventions.
Affected files:
`compiler/characterizer/simulation.py`
`compiler/characterizer/delay.py`
`compiler/characterizer/trim_spice.py`

### Testing

I tested this on my stable/local branch again with:

`python sram_compiler.py macros/sram_configs/sky130_sram_1kbyte_1rw_32x256_8.py`

and the flow completes successfully for this configuration.

### Limitations / request for review

I did not have knowledge or time to test other configs, and I also did not verify compatibility with the latest dev branch changes beyond my local environment.

Since I’m not deeply familiar with OpenRAM internals, I would appreciate maintainer review on whether these fixes are correctly scoped and whether any gating/generalization is preferred.