### PR TITLE
Fix python warnings about filehandles left open

### DIFF
--- a/compiler/debug.py
+++ b/compiler/debug.py
@@ -90,6 +90,7 @@ def log(str):
                 compile_log.write(line)
             log.setup_output = []
         compile_log.write(str + '\n')
+        compile_log.close()
     else:
         log.setup_output.append(str + "\n")
 

--- a/compiler/globals.py
+++ b/compiler/globals.py
@@ -23,7 +23,8 @@ from openram import options
 
 
 from openram import OPENRAM_HOME
-VERSION = open(OPENRAM_HOME + "/../VERSION").read().rstrip()
+with open(OPENRAM_HOME + "/../VERSION", "r", encoding="utf-8") as version_file:
+    VERSION = version_file.read().rstrip()
 NAME = "OpenRAM v{}".format(VERSION)
 USAGE = "sram_compiler.py [options] <config file>\nUse -h for help.\n"
 


### PR DESCRIPTION
We don't like python warnings, so we run with `export PYTHONWARNINGS=error`.

This floods the console with warnings like this.
```
ResourceWarning: unclosed file <_io.TextIOWrapper name='sram_1r1w_64x46/sram_1r1w_64x46.log' mode='a' encoding='UTF-8'>
Exception ignored in: <_io.FileIO name='sram_1r1w_64x46/sram_1r1w_64x46.log' mode='ab' closefd=True>
Traceback (most recent call last):
  File "../src/OpenRAM/compiler/debug.py", line 62, in print_raw
    log(str)
```

I found the problem (re-opening a file over and over again, never closing it) and fixed them by closing the filehandle after use.

Side recommendation: don't write your own logger infrastructure ever again. [Others did it for you](https://docs.python.org/3/library/logging.html)